### PR TITLE
Add a space to separate min-max length attributes

### DIFF
--- a/src/NgVal/NgVal/NgValExtensions.cs
+++ b/src/NgVal/NgVal/NgValExtensions.cs
@@ -74,10 +74,10 @@ namespace NgVal
                 case "length":
                     string lengthRes = "";
                     if (val.ValidationParameters.ContainsKey("min"))
-                        lengthRes += string.Format("ng-minlength=\"{0}\"", val.ValidationParameters["min"]);
+                        lengthRes += string.Format("ng-minlength=\"{0}\" ", val.ValidationParameters["min"]);
                     if (val.ValidationParameters.ContainsKey("max"))
                         lengthRes += string.Format("ng-maxlength=\"{0}\"", val.ValidationParameters["max"]);
-                    return lengthRes;
+                    return lengthRes.TrimEnd();
                 default:
                     return string.Format("{0}=\"{1}\"", val.ValidationType, Json.Encode(val.ValidationParameters));
             }


### PR DESCRIPTION
If a StringLength attribute is used to specify the maximum and minimum length (eg. "StringLength(140, MinimumLength=3)") then the ng-minlength and ng-maxlength attributes were not separated by a space. This fixes that.
